### PR TITLE
chore: remove the demangle call that causes issues with nvcc std c++17

### DIFF
--- a/include/tao/pegtl/normal.hpp
+++ b/include/tao/pegtl/normal.hpp
@@ -48,12 +48,8 @@ namespace tao::pegtl
       [[noreturn]] static void raise( const ParseInput& in, States&&... /*unused*/ )
       {
 #if defined( __cpp_exceptions )
-         if constexpr( internal::has_error_message< Rule > ) {
-            throw parse_error( Rule::error_message, in );
-         }
-         else {
-            throw parse_error( "parse error matching " + std::string( demangle< Rule >() ), in );
-         }
+         if constexpr( internal::has_error_message< Rule > )
+            +throw parse_error( "parse error matching " + std::string( "Rerun with prior commit -- Simplerose update used to compile with nvcc" ), in );
 #else
          static_assert( internal::dependent_false< Rule >, "exception support required for normal< Rule >::raise()" );
          (void)in;

--- a/include/tao/pegtl/normal.hpp
+++ b/include/tao/pegtl/normal.hpp
@@ -48,8 +48,12 @@ namespace tao::pegtl
       [[noreturn]] static void raise( const ParseInput& in, States&&... /*unused*/ )
       {
 #if defined( __cpp_exceptions )
-         if constexpr( internal::has_error_message< Rule > )
-            +throw parse_error( "parse error matching " + std::string( "Rerun with prior commit -- Simplerose update used to compile with nvcc" ), in );
+         if constexpr( internal::has_error_message< Rule > ) {
+            throw parse_error( Rule::error_message, in );
+         }
+         else {
+            throw parse_error( "parse error matching Rule", in );
+         }
 #else
          static_assert( internal::dependent_false< Rule >, "exception support required for normal< Rule >::raise()" );
          (void)in;


### PR DESCRIPTION
The demangle rule was causing issues when compiling the mps_reader as a library.