### PR TITLE
fix: Emit correct error with GCC

### DIFF
--- a/include/tao/pegtl/normal.hpp
+++ b/include/tao/pegtl/normal.hpp
@@ -52,7 +52,11 @@ namespace tao::pegtl
             throw parse_error( Rule::error_message, in );
          }
          else {
-            throw parse_error( "parse error matching Rule", in );
+            #ifndef __NVCC__
+               throw parse_error( "parse error matching " + std::string( demangle< Rule >() ), in );
+            #else
+               throw parse_error( "parse error matching Rule", in );
+            #endif
          }
 #else
          static_assert( internal::dependent_false< Rule >, "exception support required for normal< Rule >::raise()" );


### PR DESCRIPTION
We can make the NVCC error sexier in the future. For now the MPS reader in the SOLaaS converter will emit the correct line / col number in the file, so that is enough for a developer to find where an MPS file could be invalid. Since the NVCC-compiled MPS reader will only be used internally via BlueRose for now I think this will be acceptable.